### PR TITLE
feature/accessible-pages

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -17,6 +17,18 @@
   user-select: none;
   padding: 0;
 
+  .visuallyHidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
   > li {
     list-style: none;
   }
@@ -55,6 +67,9 @@
     a {
       text-decoration: none;
       color: #666;
+      width: 100%;
+      height: 100%;
+      display: block;
     }
 
     &:hover {

--- a/examples/focusOnListItem.html
+++ b/examples/focusOnListItem.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/focusOnListItem.js
+++ b/examples/focusOnListItem.js
@@ -1,0 +1,29 @@
+/* eslint func-names: 0, no-console: 0 */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Pagination from 'rc-pagination';
+import 'rc-pagination/assets/index.less';
+
+class App extends React.Component {
+  state = {
+    current: 3,
+  };
+  onChange = (page) => {
+    console.log(page);
+    this.setState({
+      current: page,
+    });
+  }
+  render() {
+    return (
+      <Pagination
+        focusOnListItem={false}
+        onChange={this.onChange}
+        current={this.state.current}
+        total={25}
+      />
+    );
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('__react-content'));

--- a/src/Pager.jsx
+++ b/src/Pager.jsx
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 
 const Pager = (props) => {
   const prefixCls = `${props.rootPrefixCls}-item`;
+  const ariaAttributes = {};
   let cls = `${prefixCls} ${prefixCls}-${props.page}`;
 
   if (props.active) {
     cls = `${cls} ${prefixCls}-active`;
+    ariaAttributes['aria-current'] = 'page';
   }
 
   if (props.className) {
@@ -16,6 +18,22 @@ const Pager = (props) => {
   if (!props.page) {
     cls = `${cls} ${prefixCls}-disabled`;
   }
+
+  const renderVisuallyHiddenText = () => (
+    <span className="visuallyHidden">
+      {props.active
+        ? props.locale.aria_current_page
+        : props.locale.aria_page
+      }
+    </span>
+  );
+
+  const renderLink = () => (
+    <a href="#" {...ariaAttributes}>
+      {renderVisuallyHiddenText()}
+      {props.page}
+    </a>
+  );
 
   const handleClick = () => {
     props.onClick(props.page);
@@ -31,9 +49,9 @@ const Pager = (props) => {
       className={cls}
       onClick={handleClick}
       onKeyPress={handleKeyPress}
-      tabIndex="0"
+      tabIndex={props.focusOnListItem ? 0 : null}
     >
-      {props.itemRender(props.page, 'page', <a>{props.page}</a>)}
+      {props.itemRender(props.page, 'page', renderLink())}
     </li>
   );
 };
@@ -45,6 +63,7 @@ Pager.propTypes = {
   locale: PropTypes.object,
   className: PropTypes.string,
   showTitle: PropTypes.bool,
+  focusOnListItem: PropTypes.bool,
   rootPrefixCls: PropTypes.string,
   onClick: PropTypes.func,
   onKeyPress: PropTypes.func,

--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -47,6 +47,7 @@ class Pagination extends React.Component {
     showPrevNextJumpers: PropTypes.bool,
     showQuickJumper: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     showTitle: PropTypes.bool,
+    focusOnListItem: PropTypes.bool,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.string),
     showTotal: PropTypes.func,
     locale: PropTypes.object,
@@ -73,6 +74,7 @@ class Pagination extends React.Component {
     showSizeChanger: false,
     showLessItems: false,
     showTitle: true,
+    focusOnListItem: true,
     onShowSizeChange: noop,
     locale: LOCALE,
     style: {},
@@ -451,6 +453,7 @@ class Pagination extends React.Component {
         onClick: this.handleChange,
         onKeyPress: this.runIfEnter,
         showTitle: props.showTitle,
+        focusOnListItem: props.focusOnListItem,
         itemRender: props.itemRender,
       };
       if (!allPages) {
@@ -530,6 +533,7 @@ class Pagination extends React.Component {
           page={allPages}
           active={false}
           showTitle={props.showTitle}
+          focusOnListItem={props.focusOnListItem}
           itemRender={props.itemRender}
         />
       );
@@ -543,6 +547,7 @@ class Pagination extends React.Component {
           page={1}
           active={false}
           showTitle={props.showTitle}
+          focusOnListItem={props.focusOnListItem}
           itemRender={props.itemRender}
         />
       );
@@ -570,6 +575,7 @@ class Pagination extends React.Component {
             page={i}
             active={active}
             showTitle={props.showTitle}
+            focusOnListItem={props.focusOnListItem}
             itemRender={props.itemRender}
           />
         );

--- a/src/locale/ar_EG.js
+++ b/src/locale/ar_EG.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'الذهاب إلى',
   jump_to_confirm: 'تأكيد',
   page: '',
+  aria_page: 'صفحة',
+  aria_current_page: 'الصفحه الحاليه',
 
   // Pagination.jsx
   prev_page: 'الصفحة السابقة',

--- a/src/locale/bg_BG.js
+++ b/src/locale/bg_BG.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Към',
   jump_to_confirm: 'потвърждавам',
   page: '',
+  aria_page: 'Страница',
+  aria_current_page: 'Текуща страница',
 
   // Pagination.jsx
   prev_page: 'Предишна страница',

--- a/src/locale/ca_ES.js
+++ b/src/locale/ca_ES.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Anar a',
   jump_to_confirm: 'Confirma',
   page: '',
+  aria_page: 'Página',
+  aria_current_page: 'Página actual',
 
   // Pagination.jsx
   prev_page: 'Pàgina prèvia',

--- a/src/locale/cs_CZ.js
+++ b/src/locale/cs_CZ.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Přejít',
   jump_to_confirm: 'potvrdit',
   page: '',
+  aria_page: 'Stránka',
+  aria_current_page: 'Aktuální stránka',
 
   // Pagination.jsx
   prev_page: 'Předchozí strana',

--- a/src/locale/da_DK.js
+++ b/src/locale/da_DK.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Gå til',
   jump_to_confirm: 'bekræft',
   page: '',
+  aria_page: 'Side',
+  aria_current_page: 'Nuværende side',
 
   // Pagination.jsx
   prev_page: 'Forrige Side',

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Gehe zu',
   jump_to_confirm: 'bestätigen',
   page: '',
+  aria_page: 'Seite',
+  aria_current_page: 'Aktuelle Seite',
 
   // Pagination.jsx
   prev_page: 'Vorherige Seite',

--- a/src/locale/el_GR.js
+++ b/src/locale/el_GR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Μετάβαση',
   jump_to_confirm: 'επιβεβαιώνω',
   page: '',
+  aria_page: 'Σελίδα',
+  aria_current_page: 'Τρέχουσα σελίδα',
 
   // Pagination.jsx
   prev_page: 'Προηγούμενη Σελίδα',

--- a/src/locale/en_GB.js
+++ b/src/locale/en_GB.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Goto',
   jump_to_confirm: 'confirm',
   page: '',
+  aria_page: 'Page',
+  aria_current_page: 'Current page',
 
   // Pagination.jsx
   prev_page: 'Previous Page',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Goto',
   jump_to_confirm: 'confirm',
   page: '',
+  aria_page: 'Page',
+  aria_current_page: 'Current page',
 
   // Pagination.jsx
   prev_page: 'Previous Page',

--- a/src/locale/es_ES.js
+++ b/src/locale/es_ES.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Ir a',
   jump_to_confirm: 'confirmar',
   page: '',
+  aria_page: 'Página',
+  aria_current_page: 'Página actual',
 
   // Pagination.jsx
   prev_page: 'Página anterior',

--- a/src/locale/et_EE.js
+++ b/src/locale/et_EE.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Hüppa',
   jump_to_confirm: 'Kinnitage',
   page: '',
+  aria_page: 'Leht',
+  aria_current_page: 'Käesolev lehekülg',
 
   // Pagination.jsx
   prev_page: 'Eelmine leht',

--- a/src/locale/fa_IR.js
+++ b/src/locale/fa_IR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'برو به',
   jump_to_confirm: 'تایید',
   page: '',
+  aria_page: 'صفحه',
+  aria_current_page: 'صفحه فعلی',
 
   // Pagination.jsx
   prev_page: 'صفحه قبلی',

--- a/src/locale/fi_FI.js
+++ b/src/locale/fi_FI.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Mene',
   jump_to_confirm: 'Potvrdite',
   page: '',
+  aria_page: 'Sivu',
+  aria_current_page: 'Tämänhetkinen sivu',
 
   // Pagination.jsx
   prev_page: 'Edellinen sivu',

--- a/src/locale/fr_BE.js
+++ b/src/locale/fr_BE.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Aller à',
   jump_to_confirm: 'confirmer',
   page: '',
+  aria_page: 'Page',
+  aria_current_page: 'Page actuelle',
 
   // Pagination.jsx
   prev_page: 'Page précédente',

--- a/src/locale/fr_FR.js
+++ b/src/locale/fr_FR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Aller à',
   jump_to_confirm: 'confirmer',
   page: '',
+  aria_page: 'Page',
+  aria_current_page: 'Page actuelle',
 
   // Pagination.jsx
   prev_page: 'Page précédente',

--- a/src/locale/he_IL.js
+++ b/src/locale/he_IL.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'עבור אל',
   jump_to_confirm: 'אישור',
   page: '',
+  aria_page: 'עמוד',
+  aria_current_page: 'העמוד הנוכחי',
 
   // Pagination.jsx
   prev_page: 'העמוד הקודם',

--- a/src/locale/hi_IN.js
+++ b/src/locale/hi_IN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'इस पर चलें',
   jump_to_confirm: 'पुष्टि करें',
   page: '',
+  aria_page: 'पृष्ठ',
+  aria_current_page: 'वर्तमान पृष्ठ',
 
   // Pagination.jsx
   prev_page: 'पिछला पृष्ठ',

--- a/src/locale/hr_HR.js
+++ b/src/locale/hr_HR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Idi na',
   jump_to_confirm: 'potvrdi',
   page: '',
+  aria_page: 'Stranica',
+  aria_current_page: 'Trenutna stranica',
 
   // Pagination.jsx
   prev_page: 'Prijašnja stranica',

--- a/src/locale/hu_HU.js
+++ b/src/locale/hu_HU.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Ugrás', // 'Goto',
   jump_to_confirm: 'megerősít', // 'confirm',
   page: '',
+  aria_page: 'Oldal',
+  aria_current_page: 'Aktuális oldal',
 
   // Pagination.jsx
   prev_page: 'Előző oldal', // 'Previous Page',

--- a/src/locale/id_ID.js
+++ b/src/locale/id_ID.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Menuju',
   jump_to_confirm: 'konfirmasi',
   page: '',
+  aria_page: 'Halaman',
+  aria_current_page: 'Halaman saat ini',
 
   // Pagination.jsx
   prev_page: 'Halaman Sebelumnya',

--- a/src/locale/is_IS.js
+++ b/src/locale/is_IS.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Síða',
   jump_to_confirm: 'staðfest',
   page: '',
+  aria_page: 'Síðu',
+  aria_current_page: 'Núverandi síða',
 
   // Pagination.jsx
   prev_page: 'Fyrri síða',

--- a/src/locale/it_IT.js
+++ b/src/locale/it_IT.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'vai a',
   jump_to_confirm: 'Conferma',
   page: '',
+  aria_page: 'Pagina',
+  aria_current_page: 'Pagina corrente',
 
   // Pagination.jsx
   prev_page: 'Pagina precedente',

--- a/src/locale/ja_JP.js
+++ b/src/locale/ja_JP.js
@@ -4,6 +4,8 @@ export default {
   jump_to: '移動',
   jump_to_confirm: '確認する',
   page: 'ページ',
+  aria_page: 'ページ',
+  aria_current_page: '現在のページ',
 
   // Pagination.jsx
   prev_page: '前のページ',

--- a/src/locale/kn_IN.js
+++ b/src/locale/kn_IN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'ಜಿಗಿತವನ್ನು',
   jump_to_confirm: 'ಖಚಿತಪಡಿಸಲು ಜಿಗಿತವನ್ನು',
   page: '',
+  aria_page: 'ಪುಟ',
+  aria_current_page: 'ಪ್ರಸ್ತುತ ಪುಟ',
 
   // Pagination.jsx
   prev_page: 'ಹಿಂದಿನ ಪುಟ',

--- a/src/locale/ko_KR.js
+++ b/src/locale/ko_KR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: '이동하기',
   jump_to_confirm: '확인하다',
   page: '',
+  aria_page: '페이지',
+  aria_current_page: '현재 페이지',
 
   // Pagination.jsx
   prev_page: '이전 페이지',

--- a/src/locale/ku_IQ.js
+++ b/src/locale/ku_IQ.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Biçe',
   jump_to_confirm: 'piştrast bike',
   page: '',
+  aria_page: 'Rûpel',
+  aria_current_page: 'Rûpela heyî',
 
   // Pagination.jsx
   prev_page: 'Rûpelê Pêş',

--- a/src/locale/lv_LV.js
+++ b/src/locale/lv_LV.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'iet uz',
   jump_to_confirm: 'apstiprināt',
   page: '',
+  aria_page: 'Lappuse',
+  aria_current_page: 'Pašreizējā lapa',
 
   // Pagination.jsx
   prev_page: 'Iepriekšējā lapa',

--- a/src/locale/mm_MM.js
+++ b/src/locale/mm_MM.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'သွားရန်',
   jump_to_confirm: 'သေချာပြီ',
   page: '',
+  aria_page: 'စာမျက်နှ',
+  aria_current_page: 'လက်ရှိစာမျက်နှ',
 
   // Pagination.jsx
   prev_page: 'ယခင်စာမျက်နှာ',

--- a/src/locale/mn_MN.js
+++ b/src/locale/mn_MN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Шилжих',
   jump_to_confirm: 'сонгох',
   page: '',
+  aria_page: 'Хуудас',
+  aria_current_page: 'Одоогийн хуудас',
 
   // Pagination.jsx
   prev_page: 'Өмнөх хуудас',

--- a/src/locale/ms_MY.js
+++ b/src/locale/ms_MY.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Lompat ke',
   jump_to_confirm: 'Sahkan',
   page: '',
+  aria_page: 'Halaman',
+  aria_current_page: 'Halaman saat ini',
 
   // Pagination.jsx
   prev_page: 'Halaman sebelumnya',

--- a/src/locale/nb_NO.js
+++ b/src/locale/nb_NO.js
@@ -3,6 +3,8 @@ export default {
   items_per_page: '/ side',
   jump_to: 'Gå til side',
   page: '',
+  aria_page: 'Side',
+  aria_current_page: 'Nåværende side',
 
   // Pagination.jsx
   prev_page: 'Forrige side',

--- a/src/locale/nl_BE.js
+++ b/src/locale/nl_BE.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Ga naar',
   jump_to_confirm: 'bevestigen',
   page: '',
+  aria_page: 'Bladzijde',
+  aria_current_page: 'Huidige pagina',
 
   // Pagination.jsx
   prev_page: 'Vorige pagina',

--- a/src/locale/nl_NL.js
+++ b/src/locale/nl_NL.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Ga naar',
   jump_to_confirm: 'bevestigen',
   page: '',
+  aria_page: 'Bladzijde',
+  aria_current_page: 'Huidige pagina',
 
   // Pagination.jsx
   prev_page: 'Vorige pagina',

--- a/src/locale/pa_IN.js
+++ b/src/locale/pa_IN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Goto',
   jump_to_confirm: 'ਪੁਸ਼ਟੀ ਕਰੋ',
   page: 'ਪੰਨਾ',
+  aria_page: 'ਪੇਜ',
+  aria_current_page: 'ਮੌਜੂਦਾ ਪੇਜ',
 
   // Pagination.jsx
   prev_page: 'ਪਿਛਲਾ ਪੰਨਾ',

--- a/src/locale/pb_IN.js
+++ b/src/locale/pb_IN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Goto',
   jump_to_confirm: 'ਪੁਸ਼ਟੀ ਕਰੋ',
   page: 'ਪੰਨਾ',
+  aria_page: 'ਪੇਜ',
+  aria_current_page: 'ਮੌਜੂਦਾ ਪੇਜ',
 
   // Pagination.jsx
   prev_page: 'ਪਿਛਲਾ ਪੰਨਾ',

--- a/src/locale/pl_PL.js
+++ b/src/locale/pl_PL.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Idź do',
   jump_to_confirm: 'potwierdzać',
   page: '',
+  aria_page: 'Strona',
+  aria_current_page: 'Bieżąca strona',
 
   // Pagination.jsx
   prev_page: 'Poprzednia strona',

--- a/src/locale/pt_BR.js
+++ b/src/locale/pt_BR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Vá até',
   jump_to_confirm: 'confirme',
   page: '',
+  aria_page: 'Página',
+  aria_current_page: 'Pagina atual',
 
   // Pagination.jsx
   prev_page: 'Página anterior',

--- a/src/locale/pt_PT.js
+++ b/src/locale/pt_PT.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Saltar',
   jump_to_confirm: 'confirmar',
   page: '',
+  aria_page: 'Página',
+  aria_current_page: 'Pagina atual',
 
   // Pagination.jsx
   prev_page: 'Página Anterior',

--- a/src/locale/ro_RO.js
+++ b/src/locale/ro_RO.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Mergi la',
   jump_to_confirm: 'confirm',
   page: '',
+  aria_page: 'Pagină',
+  aria_current_page: 'Pagina curenta',
 
   // Pagination.jsx
   prev_page: 'Pagina Anterioară',

--- a/src/locale/ru_RU.js
+++ b/src/locale/ru_RU.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Перейти',
   jump_to_confirm: 'подтвердить',
   page: '',
+  aria_page: 'Страница',
+  aria_current_page: 'Текущая страница',
 
   // Pagination.jsx
   prev_page: 'Назад',

--- a/src/locale/sk_SK.js
+++ b/src/locale/sk_SK.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Choď na',
   jump_to_confirm: 'potvrdit',
   page: '',
+  aria_page: 'Strana',
+  aria_current_page: 'Aktuálna stránka',
 
   // Pagination.jsx
   prev_page: 'Predchádzajúca strana',

--- a/src/locale/sl_SI.js
+++ b/src/locale/sl_SI.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Pojdi na',
   jump_to_confirm: 'potrdi',
   page: '',
+  aria_page: 'Stran',
+  aria_current_page: 'Trenutna stran',
 
   // Pagination.jsx
   prev_page: 'Prejšnja stran',

--- a/src/locale/sr_RS.js
+++ b/src/locale/sr_RS.js
@@ -3,6 +3,8 @@ export default {
   items_per_page: '/ strani',
   jump_to: 'Idi na',
   page: '',
+  aria_page: 'Stranica',
+  aria_current_page: 'Trenutna stranica',
 
   // Pagination.jsx
   prev_page: 'Prethodna strana',

--- a/src/locale/sv_SE.js
+++ b/src/locale/sv_SE.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Gå till',
   jump_to_confirm: 'bekräfta',
   page: '',
+  aria_page: 'Side',
+  aria_current_page: 'Nuvarande sida',
 
   // Pagination.jsx
   prev_page: 'Föreg sida',

--- a/src/locale/ta_IN.js
+++ b/src/locale/ta_IN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'அடுத்த',
   jump_to_confirm: 'உறுதிப்படுத்தவும்',
   page: '',
+  aria_page: 'பக்கம்',
+  aria_current_page: 'தற்போதைய பக்கம்',
 
   // Pagination.jsx
   prev_page: 'முந்தைய பக்கம்',

--- a/src/locale/th_TH.js
+++ b/src/locale/th_TH.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'ไปยัง',
   jump_to_confirm: 'ยืนยัน',
   page: '',
+  aria_page: 'หน้า',
+  aria_current_page: 'หน้าปัจจุบัน',
 
   // Pagination.jsx
   prev_page: 'หน้าก่อนหน้า',

--- a/src/locale/tr_TR.js
+++ b/src/locale/tr_TR.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Git',
   jump_to_confirm: 'onayla',
   page: '',
+  aria_page: 'Sayfa',
+  aria_current_page: 'Geçerli sayfa',
 
   // Pagination.jsx
   prev_page: 'Önceki Sayfa',

--- a/src/locale/ug_CN.js
+++ b/src/locale/ug_CN.js
@@ -4,6 +4,9 @@ export default {
   jump_to: 'بەتكە سەكرەش',
   jump_to_confirm: 'مۇقىملاشتۇرۇش',
   page: 'بەت',
+  aria_page: 'صفحة',
+  aria_current_page: 'الصفحه الحاليه',
+
   // Pagination.jsx
   prev_page: 'ئالدىنقى',
   next_page: 'كېيىنكى',

--- a/src/locale/uk_UA.js
+++ b/src/locale/uk_UA.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Перейти',
   jump_to_confirm: 'підтвердити',
   page: '',
+  aria_page: 'Сторінка',
+  aria_current_page: 'Поточна сторінка',
 
   // Pagination.jsx
   prev_page: 'Попередня сторінка',

--- a/src/locale/vi_VN.js
+++ b/src/locale/vi_VN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: 'Đến',
   jump_to_confirm: 'xác nhận',
   page: '',
+  aria_page: 'Trang',
+  aria_current_page: 'Trang hiện tại',
 
   // Pagination.jsx
   prev_page: 'Trang Trước',

--- a/src/locale/zh_CN.js
+++ b/src/locale/zh_CN.js
@@ -4,6 +4,8 @@ export default {
   jump_to: '跳至',
   jump_to_confirm: '确定',
   page: '页',
+  aria_page: '页',
+  aria_current_page: '当前页面',
 
   // Pagination.jsx
   prev_page: '上一页',

--- a/src/locale/zh_TW.js
+++ b/src/locale/zh_TW.js
@@ -4,6 +4,8 @@ export default {
   jump_to: '跳至',
   jump_to_confirm: '確定',
   page: '頁',
+  aria_page: '頁',
+  aria_current_page: '當前頁面',
 
   // Pagination.jsx
   prev_page: '上一頁',


### PR DESCRIPTION
Introducing prop - `focusOnListItem` which enable/disable focus for `<li>`.
Currently it is enable by default, but there is many accessibility cases when focus is needed for child element (link or button).

This feature will make accessible page links by adding `aria-current="page"` and add visually hidden text inside link - "Page", so screen readers will pronounce "Page 1" instead of just "1".

Pagination accessibility best practices:
https://a11y-style-guide.com/style-guide/section-navigation.html#kssref-navigation-pagination